### PR TITLE
Teyssieuman patch 1

### DIFF
--- a/src/TurtleMineShared/FeedParser.cs
+++ b/src/TurtleMineShared/FeedParser.cs
@@ -42,7 +42,7 @@ namespace TurtleMine
 			}
 
 			//Remove BaseRedmineUrl and "Issues" wording
-			projectUrlPath = feed.Links[0].Uri.AbsoluteUri.Replace(baseRedmineUrl, String.Empty).Replace("/issues.atom", String.Empty).Replace("/issues", String.Empty);
+			projectUrlPath = feed.Links[0].Uri.AbsoluteUri.Replace(baseRedmineUrl, String.Empty).Replace("issues.atom", String.Empty).Replace("/issues", String.Empty);
 
 			//Also remove Url Query info if exists
 			if (!String.IsNullOrEmpty(feed.Links[0].Uri.Query))

--- a/src/TurtleMineShared/VersionCheck.cs
+++ b/src/TurtleMineShared/VersionCheck.cs
@@ -16,7 +16,7 @@ namespace TurtleMine
         /// </summary>
         public VersionCheck()
         {
-            const string versionUrl = "http://turtlemine.googlecode.com/svn/trunk/Version/Version.xml";
+            const string versionUrl = "https://raw.githubusercontent.com/jlestein/turtlemine/master/Version/Version.xml";
             
             try
             {


### PR DESCRIPTION
Obtain the "feed" URL by removing "issues.atom" instead of "/issues.atom".

The feed.Links[0].Uri.AbsoluteUri (line 45) fo not contains the first "/" character, the replacement cannot be done.
If the character in contained, an extra "/" will be present on the URL. It is not a problem since the URL format is roust to that.