### PR TITLE
Patch ConnectionHelper.cs to support TLS1.2

### DIFF
--- a/src/TurtleMineShared/ConnectionHelper.cs
+++ b/src/TurtleMineShared/ConnectionHelper.cs
@@ -81,10 +81,17 @@ namespace TurtleMine
 			var client = new CertWebClient { Proxy = prox, Credentials = cred, CertPath = certPath };
 
 			//Provide support for SSL by accepting all certificates
-			ServicePointManager.ServerCertificateValidationCallback += delegate { return true; };  
+			ServicePointManager.ServerCertificateValidationCallback += delegate { return true; };
 
-			//Read the url
-			if (url != null)
+            //Support TLS 1.2 by manually providing a proper value for the certificate. Other versions of the protocol are listed below.
+            //Ssl3 = 48, Tls = 192, Tls11 = 768, Tls12 = 3072
+            //ServicePointManager.SecurityProtocol = (SecurityProtocolType)48 | (SecurityProtocolType)192 | (SecurityProtocolType)768 | (SecurityProtocolType)3072;
+            //Author: Kenan Dervišević
+            //Company: Siemens Mobility
+            ServicePointManager.SecurityProtocol = (SecurityProtocolType)3072;
+
+            //Read the url
+            if (url != null)
 			{
 				var rmstream = client.OpenRead(url);
 				if (rmstream != null)


### PR DESCRIPTION
Hello Joshua,
Current version of the TurtleMine doesn't handle TLS1.2 very well. In order to add support for it, I'm providing you with a patch which is adding support for it.
I'm only enabling TLS 1.2 in the code, as other versions are considered to be insecure. To support all protocols, use the commented out line 88 instead of line 91.

Another approach would be to move to a newer version of .NET Framework (4.6), but this would require more testing if something else is broken. I haven't tested this.

More details on the issue with TLS:
https://support.microsoft.com/en-us/help/3154517/support-for-tls-system-default-versions-included-in-the--net-framework
http://blogs.perficient.com/microsoft/2016/04/tsl-1-2-and-net-support/
https://stackoverflow.com/questions/33761919/tls-1-2-in-net-framework-4-0

Tested with:
TortoiseSVN 1.9.5, Build 27581 - 64 Bit , 2016/11/26 09:18:58
Visual Studio Community 2017
Visual Studio Professional 2013